### PR TITLE
fix list of npm bundle files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "description": "React용 카카오 링크",
   "main": "./dist/index.js",
+  "types": "./index.d.ts",
   "files": [
-    "dist"
+    "./dist",
+    "./index.d.ts"
   ],
-  "typings": "index.d.ts",
   "repository": "https://github.com/heyman333/react-kakao-link.git",
   "author": "youngsoohan <amazingmobdev@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
### current problem
current npm release of the package doesn't include declaration file because `d.ts` file wasn't listed in `"files"` of `package.json`

```
Could not find a declaration file for module 'react-kakao-link'. './node_modules/react-kakao-link/dist/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/react-kakao-link` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-kakao-link';`  TS7016
```

### what's changed
added `./index.d.ts` to `"files"`

### references
> package.json이 "files" 프로퍼티를 포함하고 있으면 "types" 프로퍼티는 무시됩니다. 이 경우 메인 선언 파일을 "files" 프로퍼티에 전달해야 합니다.
https://www.typescriptlang.org/ko/docs/handbook/declaration-files/publishing.html
